### PR TITLE
prevent deploy on pull_request

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -48,6 +48,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages
+        if: github.event_name != 'pull_request'
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"


### PR DESCRIPTION
@bniebuhr this prevents pushing to github pages if the triggering event is a pull request.

For security reason it's better to just test that the build work in the pull request, while performing the action that changes the website when a commit is done on master/main